### PR TITLE
fix SendGridExtension namespace in config call

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In config add:
 
 ```
 extension:
-    sendgrid: Price2Performance\SendGrid\SendGridExtension
+    sendgrid: Price2Performance\SendGrid\DI\SendGridExtension
 
 sendgrid:
     key: 'SECRET_KEY'


### PR DESCRIPTION
The last line was changed by GitHub online editor. I don't know why, I don't see any difference.