### PR TITLE
SendGridMailer implements Mailer

### DIFF
--- a/src/SendGridMailer.php
+++ b/src/SendGridMailer.php
@@ -2,13 +2,14 @@
 
 namespace Price2Performance\SendGrid;
 
+use Nette\Mail\Mailer;
 use Nette\Mail\Message;
 use Nette\SmartObject;
 use SendGrid;
 use SendGrid\Mail\Mail;
 use SendGrid\Response;
 
-class SendGridMailer
+class SendGridMailer implements Mailer
 {
     use SmartObject;
 


### PR DESCRIPTION
SendGridMailer already meets requirements defined in interface `Nette\Mail\Mailer`. Explicitly stating so allows requesting an interface rather than SendGridMailer specifically (dependency inversion principle).

```php
MyModel {
  public function __construct(
    \Nette\Mail\Mailer $mailer
  ) { ... }
}
```