### PR TITLE
DI: Allow dynamic parameter for key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Sendgrid integration for Nette.",
     "require": {
         "php": ">=7.1",
-        "nette/mail": "^3.0",
+        "nette/mail": "^3.0|^4.0",
         "nette/di": "^3.0",
         "sendgrid/sendgrid": "^7.4"
     },

--- a/src/DI/SendGridExtension.php
+++ b/src/DI/SendGridExtension.php
@@ -14,7 +14,7 @@ class SendGridExtension extends CompilerExtension
     public function getConfigSchema(): Schema
 	{
 		return Expect::structure([
-			'key' => Expect::string(),
+			'key' => Expect::string()->dynamic(),
 			'options' => Expect::anyof(
 				Expect::string(),
 				Expect::array()


### PR DESCRIPTION
Fixes
```
Nette\DI\InvalidConfigurationException

The item 'sendgrid › key' expects to be string, object Nette\DI\DynamicParameter given.
````